### PR TITLE
fix: actions only supports node12 and node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Copy the annotation from the latest tag'
     default: false
 runs:
-  using: 'node14'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node14' is not supported, use 'docker', 'node12' or 'node16' instead.')