### PR TITLE
chore: `omit=peer`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
+omit=peer
 # ignore-scripts=true This causes `npm test` to not run (node 14, npm 6, on CI)


### PR DESCRIPTION
This prevents peerDependencies from auto installing and messing things up. It is trying to fix the lockfile regen PR with the error `RangeError: Found invalid rule names: header-trim.`.